### PR TITLE
[v0.2.4]  Support for Discarded parameters and utilizing Filter values (Fixes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Internal URLs
 [release]:https://github.com/abhiTronix/deffcode/releases/latest
 [recipes]:https://abhitronix.github.io/deffcode/latest/recipes/basic/
 [license]:https://github.com/abhiTronix/deffcode/blob/master/LICENSE
-[help]:https://abhitronix.github.io/deffcode/latest/https://abhitronix.github.io/deffcode/latest/help/get_help
+[help]:https://abhitronix.github.io/deffcode/latest/help/get_help
 [installation-notes]:https://abhitronix.github.io/deffcode/latest/installation/#installation-notes
 [ffdecoder-api]:https://abhitronix.github.io/deffcode/latest/reference/ffdecoder/#ffdecoder-api
 [sourcer-api]:https://abhitronix.github.io/deffcode/latest/reference/sourcer/#sourcer-api

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -663,15 +663,6 @@ class FFdecoder:
                     self.__raw_frame_depth,
                 )
             )[:, :, 0]
-        elif self.__raw_frame_pixfmt.startswith("yuv"):
-            # reconstruct exclusive `yuv` frames
-            frame = frame.reshape(
-                (
-                    self.__raw_frame_depth,
-                    self.__raw_frame_resolution[1],
-                    self.__raw_frame_resolution[0],
-                )
-            ).transpose((1, 2, 0))
         else:
             # reconstruct default frames
             frame = frame.reshape(

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -586,7 +586,7 @@ class FFdecoder:
             # TODO Added support for `-re -stream_loop` and `-loop`
             if "-frames:v" in input_params:
                 self.__raw_frame_num = input_params["-frames:v"]
-            elif self.__sourcer_metadata["approx_video_nframes"]:
+            elif self.__sourcer_metadata["approx_video_nframes"] > 0:
                 self.__raw_frame_num = self.__sourcer_metadata["approx_video_nframes"]
             else:
                 self.__raw_frame_num = None
@@ -746,10 +746,10 @@ class FFdecoder:
             default_keys = set(value).intersection(self.__sourcer_metadata)
             # iterate over source metadata keys and sanitize it
             for key in default_keys or []:
-                if key == "source":
-                    # `source` metadata value cannot be altered
+                if key in ["source", "source_video_pixfmt"]:
+                    # metadata properties that cannot be altered
                     logger.warning(
-                        "`source` metadata value cannot be altered. Discarding!"
+                        "`{}` metadata property value cannot be altered. Discarding!".format(key)
                     )
                 elif isinstance(value[key], type(self.__sourcer_metadata[key])):
                     # check if correct datatype as original
@@ -759,7 +759,7 @@ class FFdecoder:
                 else:
                     # otherwise discard and log it
                     logger.warning(
-                        "Manually assigned `{}` metadata value is invalid type. Discarding!"
+                        "Manually assigned `{}` metadata property value is of invalid type. Discarding!"
                     ).format(key)
                 # delete invalid key
                 del value[key]
@@ -767,7 +767,7 @@ class FFdecoder:
             # Python's `json` module converts Python tuples to JSON lists
             # because that's the closest thing in JSON to a tuple.
             any(isinstance(value[x], tuple) for x in value) and logger.warning(
-                "All TUPLE metadata values will be converted to LIST datatype. Read docs for more details."
+                "All TUPLE metadata properties will be converted to LIST datatype. Read docs for more details."
             )
             # update user-defined metadata
             self.__user_metadata.update(value)

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -414,9 +414,9 @@ class FFdecoder:
                 else:
                     not (self.__frame_format is None) and logger.warning(
                         "Provided FFmpeg not supports `{}` pixel-format. Switching to default `{}`!".format(
-                            self.__frame_format
+                            self.__sourcer_metadata["output_frames_pixfmt"]
                             if "output_frames_pixfmt" in self.__sourcer_metadata
-                            else self.__sourcer_metadata["output_frames_pixfmt"],
+                            else self.__frame_format,
                             default_pixfmt,
                         )
                     )

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -429,9 +429,11 @@ class FFdecoder:
                 if x[0] == rawframe_pixfmt
             ][0]
             raw_bit_per_component = rawframesbpp // self.__raw_frame_depth
-            if raw_bit_per_component in [4, 8]:
+            if 4 <= raw_bit_per_component <= 8:
                 self.__raw_frame_dtype = np.dtype("u1")
-            elif raw_bit_per_component == 16 and rawframe_pixfmt.endswith(("le", "be")):
+            elif 8 < raw_bit_per_component <= 16 and rawframe_pixfmt.endswith(
+                ("le", "be")
+            ):
                 if rawframe_pixfmt.endswith("le"):
                     self.__raw_frame_dtype = np.dtype("<u2")
                 else:

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -784,6 +784,15 @@ class FFdecoder:
                     )
                 elif isinstance(value[key], type(self.__sourcer_metadata[key])):
                     # check if correct datatype as original
+                    self.__verbose_logs and logger.info(
+                        "Updating `{}`{} metadata property to `{}`.".format(
+                            key,
+                            " and its counterpart"
+                            if key in counterpart_prop.values()
+                            else "",
+                            value[key],
+                        )
+                    )
                     # update source metadata if valid
                     self.__sourcer_metadata[key] = value[key]
                     # also update missing counterpart property (if available)

--- a/deffcode/ffdecoder.py
+++ b/deffcode/ffdecoder.py
@@ -769,7 +769,7 @@ class FFdecoder:
                             key
                         )
                     )
-                elif self.__missing_prop != {} and key in self.__missing_prop:
+                elif key in self.__missing_prop:
                     # missing metadata properties are unavailable and read-only
                     # notify user about alternative counterpart property (if available)
                     logger.warning(
@@ -785,14 +785,13 @@ class FFdecoder:
                 elif isinstance(value[key], type(self.__sourcer_metadata[key])):
                     # check if correct datatype as original
                     # update source metadata if valid
-                    self.__sourcer_metadata.update(value)
+                    self.__sourcer_metadata[key] = value[key]
                     # also update missing counterpart property (if available)
                     counter_key = next(
                         (k for k, v in counterpart_prop.items() if v == key), ""
                     )
                     if counter_key:
                         self.__missing_prop[counter_key] = value[key]
-                    continue
                 else:
                     # otherwise discard and log it
                     logger.warning(

--- a/deffcode/sourcer.py
+++ b/deffcode/sourcer.py
@@ -28,7 +28,7 @@ import platform
 import numpy as np
 
 # import utils packages
-from .utils import logger_handler, validate_device_index
+from .utils import logger_handler, validate_device_index, dict2Args
 from .ffhelper import (
     check_sp_output,
     get_supported_demuxers,
@@ -101,7 +101,7 @@ class Sourcer:
         # sanitize sourcer_params
         self.__sourcer_params = {
             str(k).strip(): str(v).strip()
-            if not isinstance(v, (dict, list, int, float))
+            if not isinstance(v, (dict, list, int, float, tuple))
             else v
             for k, v in sourcer_params.items()
         }
@@ -189,7 +189,7 @@ class Sourcer:
         # handles source stream
         self.__source = source
 
-        # create shallow copy for further usage #TODO
+        # creates shallow copy for further usage #TODO
         self.__source_org = copy.copy(self.__source)
         self.__source_demuxer_org = copy.copy(self.__source_demuxer)
 
@@ -198,22 +198,28 @@ class Sourcer:
         self.__extracted_devices_list = []
 
         # various source stream params
-        self.__default_video_resolution = ""  # handle stream resolution
-        self.__default_video_framerate = ""  # handle stream framerate
-        self.__default_video_bitrate = ""  # handle stream's video bitrate
-        self.__default_video_pixfmt = ""  # handle stream's video pixfmt
-        self.__default_video_decoder = ""  # handle stream's video decoder
-        self.__default_source_duration = ""  # handle stream's video duration
-        self.__approx_video_nframes = ""  # handle approx stream frame number
-        self.__default_audio_bitrate = ""  # handle stream's audio bitrate
-        self.__default_audio_samplerate = ""  # handle stream's audio samplerate
+        self.__default_video_resolution = ""  # handles stream resolution
+        self.__default_video_framerate = ""  # handles stream framerate
+        self.__default_video_bitrate = ""  # handles stream's video bitrate
+        self.__default_video_pixfmt = ""  # handles stream's video pixfmt
+        self.__default_video_decoder = ""  # handles stream's video decoder
+        self.__default_source_duration = ""  # handles stream's video duration
+        self.__approx_video_nframes = ""  # handles approx stream frame number
+        self.__default_audio_bitrate = ""  # handles stream's audio bitrate
+        self.__default_audio_samplerate = ""  # handles stream's audio samplerate
 
         # handle various stream flags
-        self.__contains_video = False  # contain video
-        self.__contains_audio = False  # contain audio
-        self.__contains_images = False  # contain image-sequence
+        self.__contains_video = False  # contains video
+        self.__contains_audio = False  # contains audio
+        self.__contains_images = False  # contains image-sequence
 
-        # check whether metadata probed or not
+        # handles output parameters through filters
+        self.__metadata_output = None  # handles output stream metadata
+        self.__output_video_resolution = ""  # handles output stream resolution
+        self.__output_video_framerate = ""  # handles output stream framerate
+        self.__output_frames_pixfmt = ""  # handles output frame pixel format
+
+        # check whether metadata probed or not?
         self.__metadata_probed = False
 
     def probe_stream(self, default_stream_indexes=(0, 0)):
@@ -245,10 +251,26 @@ class Sourcer:
         if video_rfparams:
             self.__default_video_resolution = video_rfparams["resolution"]
             self.__default_video_framerate = video_rfparams["framerate"]
-        # parse pixel format
+
+        # parse output parameters through filters (if available)
+        if not (self.__metadata_output is None):
+            # parse output resolution and framerate
+            out_video_rfparams = self.__extract_resolution_framerate(
+                default_stream=default_stream_indexes[0], extract_output=True
+            )
+            if out_video_rfparams:
+                self.__output_video_resolution = out_video_rfparams["resolution"]
+                self.__output_video_framerate = out_video_rfparams["framerate"]
+            # parse output pixel-format
+            self.__output_frames_pixfmt = self.__extract_video_pixfmt(
+                default_stream=default_stream_indexes[0], extract_output=True
+            )
+
+        # parse pixel-format
         self.__default_video_pixfmt = self.__extract_video_pixfmt(
             default_stream=default_stream_indexes[0]
         )
+
         # parse video decoder
         self.__default_video_decoder = self.__extract_video_decoder(
             default_stream=default_stream_indexes[0]
@@ -344,6 +366,15 @@ class Sourcer:
                 "source_has_image_sequence": self.__contains_images,
             }
         )
+        # handle output parameter if available
+        if not (self.__metadata_output is None):
+            metadata.update(
+                {
+                    "output_video_resolution": self.__output_video_resolution,
+                    "output_video_framerate": self.__output_video_framerate,
+                    "output_frames_pixfmt": self.__output_frames_pixfmt,
+                }
+            )
         # log it
         self.__verbose_logs and logger.debug(
             "Metadata Extraction completed successfully!"
@@ -462,17 +493,41 @@ class Sourcer:
             logger.error("`source` value is unusable or unsupported!")
             # discard the value otherwise
             raise ValueError("Input source is invalid. Aborting!")
-        # extract metadata
-        metadata = check_sp_output(
-            [self.__ffmpeg]
-            + (["-hide_banner"] if not self.__verbose_logs else [])
-            + self.__ffmpeg_prefixes
-            + (["-f", source_demuxer] if source_demuxer else [])
-            + ["-i", source],
-            force_retrieve_stderr=True,
+        # format command
+        if self.__sourcer_params:
+            # handle additional params separately
+            meta_cmd = (
+                [self.__ffmpeg]
+                + (["-hide_banner"] if not self.__verbose_logs else [])
+                + ["-t", "0.0001"]
+                + self.__ffmpeg_prefixes
+                + (["-f", source_demuxer] if source_demuxer else [])
+                + ["-i", source]
+                + dict2Args(self.__sourcer_params)
+                + ["-f", "null", "-"]
+            )
+        else:
+            meta_cmd = (
+                [self.__ffmpeg]
+                + (["-hide_banner"] if not self.__verbose_logs else [])
+                + self.__ffmpeg_prefixes
+                + (["-f", source_demuxer] if source_demuxer else [])
+                + ["-i", source]
+            )
+        # extract metadata, decode, and filter
+        metadata = (
+            check_sp_output(
+                meta_cmd,
+                force_retrieve_stderr=True,
+            )
+            .decode("utf-8")
+            .strip()
         )
-        # filter and return
-        return metadata.decode("utf-8").strip()
+        # separate input and output metadata (if available)
+        if "Output #" in metadata:
+            (metadata, self.__metadata_output) = metadata.split("Output #")
+        # return metadata based on params
+        return metadata
 
     def __extract_video_bitrate(self, default_stream=0):
         """
@@ -536,7 +591,7 @@ class Sourcer:
                 return filtered_pixfmt[0].split(" ")[-1]
         return ""
 
-    def __extract_video_pixfmt(self, default_stream=0):
+    def __extract_video_pixfmt(self, default_stream=0, extract_output=False):
         """
         This Internal method parses default video-stream pixel-format from metadata.
 
@@ -546,11 +601,19 @@ class Sourcer:
         **Returns:** Default Video pixel-format as string value.
         """
         identifiers = ["Video:", "Stream #"]
-        meta_text = [
-            line.strip()
-            for line in self.__ffsp_output.split("\n")
-            if all(x in line for x in identifiers)
-        ]
+        meta_text = (
+            [
+                line.strip()
+                for line in self.__ffsp_output.split("\n")
+                if all(x in line for x in identifiers)
+            ]
+            if not extract_output
+            else [
+                line.strip()
+                for line in self.__metadata_output.split("\n")
+                if all(x in line for x in identifiers)
+            ]
+        )
         if meta_text:
             selected_stream = meta_text[
                 default_stream
@@ -610,21 +673,31 @@ class Sourcer:
             )
         return result if result and (len(result) == 2) else {}
 
-    def __extract_resolution_framerate(self, default_stream=0):
+    def __extract_resolution_framerate(self, default_stream=0, extract_output=False):
         """
         This Internal method parses default video-stream resolution and framerate from metadata.
 
         Parameters:
             default_stream (int): selects specific audio-stream in case of multiple ones.
+            extract_output (bool): Whether to extract from output(if true) or input(if false) stream?
 
         **Returns:** Default Video resolution and framerate as dictionary value.
         """
         identifiers = ["Video:", "Stream #"]
-        meta_text = [
-            line.strip()
-            for line in self.__ffsp_output.split("\n")
-            if all(x in line for x in identifiers)
-        ]
+        # use output metadata if available
+        meta_text = (
+            [
+                line.strip()
+                for line in self.__ffsp_output.split("\n")
+                if all(x in line for x in identifiers)
+            ]
+            if not extract_output
+            else [
+                line.strip()
+                for line in self.__metadata_output.split("\n")
+                if all(x in line for x in identifiers)
+            ]
+        )
         result = {}
         if meta_text:
             selected_stream = meta_text[

--- a/deffcode/utils.py
+++ b/deffcode/utils.py
@@ -78,7 +78,7 @@ def logger_handler():
 
 
 # define logger
-logger = logging.getLogger("Utilies")
+logger = logging.getLogger("Utilities")
 logger.propagate = False
 logger.addHandler(logger_handler())
 logger.setLevel(logging.DEBUG)

--- a/docs/recipes/advanced/transcode-art-filtergraphs.md
+++ b/docs/recipes/advanced/transcode-art-filtergraphs.md
@@ -121,7 +121,7 @@ decoder = FFdecoder("foo.mp4", frame_format="bgr24", verbose=True, **ffparams).f
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
 }
 
 # Define writer with default parameters and suitable
@@ -198,7 +198,7 @@ decoder = FFdecoder(
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
 }
 
 # Define writer with default parameters and suitable
@@ -266,7 +266,7 @@ decoder = FFdecoder(
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
 }
 
 # Define writer with default parameters and suitable
@@ -334,7 +334,7 @@ decoder = FFdecoder(
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
 }
 
 # Define writer with default parameters and suitable

--- a/docs/recipes/advanced/transcode-hw-acceleration.md
+++ b/docs/recipes/advanced/transcode-hw-acceleration.md
@@ -163,7 +163,7 @@ decoder = FFdecoder(
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
     "-vcodec": "h264_nvenc",  # H.264 NVENC encoder
     "–resize": "1280x720",  # rescale to 1280x720
 }

--- a/docs/recipes/advanced/transcode-live-frames-complexgraphs.md
+++ b/docs/recipes/advanced/transcode-live-frames-complexgraphs.md
@@ -122,7 +122,7 @@ decoder = FFdecoder(
 # retrieve framerate from source JSON Metadata and pass it as `-input_framerate`
 # parameter for controlled framerate and define other parameters
 output_params = {
-    "-input_framerate": json.loads(decoder.metadata)["source_video_framerate"],
+    "-input_framerate": json.loads(decoder.metadata)["output_framerate"],
 }
 
 # Define writer with default parameters and suitable

--- a/docs/recipes/basic/transcode-live-frames-simplegraphs.md
+++ b/docs/recipes/basic/transcode-live-frames-simplegraphs.md
@@ -85,7 +85,7 @@ In this example we will take the first 5 seconds of a video clip _(using [`trim`
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
-!!! tip "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve source framerate and resolution."
+!!! tip "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve output framerate and resolution."
 
 !!! alert "By default, OpenCV expects `BGR` format frames in its `cv2.write()` method."
 
@@ -110,8 +110,8 @@ metadata_dict = json.loads(decoder.metadata)
 
 # prepare OpenCV parameters
 FOURCC = cv2.VideoWriter_fourcc("M", "J", "P", "G")
-FRAMERATE = metadata_dict["source_video_framerate"]
-FRAMESIZE = tuple(metadata_dict["source_video_resolution"])
+FRAMERATE = metadata_dict["output_framerate"]
+FRAMESIZE = tuple(metadata_dict["output_frames_resolution"])
 
 # Define writer with parameters and suitable output filename for e.g. `output_foo.avi`
 writer = cv2.VideoWriter("output_foo.avi", FOURCC, FRAMERATE, FRAMESIZE)
@@ -149,7 +149,7 @@ In this example we will crop real-time video frames by an area with size 2/3 of 
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
-!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve source framerate and resolution."
+!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve output framerate and resolution."
 
 !!! tip "More complex examples using `crop` filter can be found [here ➶](https://ffmpeg.org/ffmpeg-filters.html#toc-Examples-57) and can be applied similarly."
 
@@ -174,8 +174,8 @@ metadata_dict = json.loads(decoder.metadata)
 
 # prepare OpenCV parameters
 FOURCC = cv2.VideoWriter_fourcc("M", "J", "P", "G")
-FRAMERATE = metadata_dict["source_video_framerate"]
-FRAMESIZE = tuple(metadata_dict["source_video_resolution"])
+FRAMERATE = metadata_dict["output_framerate"]
+FRAMESIZE = tuple(metadata_dict["output_frames_resolution"])
 
 # Define writer with parameters and suitable output filename for e.g. `output_foo.avi`
 writer = cv2.VideoWriter("output_foo.avi", FOURCC, FRAMERATE, FRAMESIZE)
@@ -215,7 +215,7 @@ In this example we will rotate real-time video frames at an arbitrary angle by a
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
-!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve source framerate and resolution."
+!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve output framerate and resolution."
 
 ```python
 # import the necessary packages
@@ -238,8 +238,8 @@ metadata_dict = json.loads(decoder.metadata)
 
 # prepare OpenCV parameters
 FOURCC = cv2.VideoWriter_fourcc("M", "J", "P", "G")
-FRAMERATE = metadata_dict["source_video_framerate"]
-FRAMESIZE = tuple(metadata_dict["source_video_resolution"])
+FRAMERATE = metadata_dict["output_framerate"]
+FRAMESIZE = tuple(metadata_dict["output_frames_resolution"])
 
 # Define writer with parameters and suitable output filename for e.g. `output_foo.avi`
 writer = cv2.VideoWriter("output_foo.avi", FOURCC, FRAMERATE, FRAMESIZE)
@@ -278,7 +278,7 @@ In this example we will rotate real-time video frames by 90 degrees counterclock
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
-!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve source framerate and resolution."
+!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve output framerate and resolution."
 
 ```python
 # import the necessary packages
@@ -301,8 +301,8 @@ metadata_dict = json.loads(decoder.metadata)
 
 # prepare OpenCV parameters
 FOURCC = cv2.VideoWriter_fourcc("M", "J", "P", "G")
-FRAMERATE = metadata_dict["source_video_framerate"]
-FRAMESIZE = tuple(metadata_dict["source_video_resolution"])
+FRAMERATE = metadata_dict["output_framerate"]
+FRAMESIZE = tuple(metadata_dict["output_frames_resolution"])
 
 # Define writer with parameters and suitable output filename for e.g. `output_foo.avi`
 writer = cv2.VideoWriter("output_foo.avi", FOURCC, FRAMERATE, FRAMESIZE)
@@ -339,7 +339,7 @@ In this example we will horizontally flip and scale real-time video frames to ha
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
-!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve source framerate and resolution."
+!!! note "You can use FFdecoder's [`metadata`](../../reference/ffdecoder/#deffcode.ffdecoder.FFdecoder.metadata) property object that dumps source Video's metadata information _(as JSON string)_ to retrieve output framerate and resolution."
 
 !!! tip "More complex examples using `scale` filter can be found [here ➶](https://ffmpeg.org/ffmpeg-filters.html#toc-Examples-107) and can be applied similarly."
 
@@ -364,8 +364,8 @@ metadata_dict = json.loads(decoder.metadata)
 
 # prepare OpenCV parameters
 FOURCC = cv2.VideoWriter_fourcc("M", "J", "P", "G")
-FRAMERATE = metadata_dict["source_video_framerate"]
-FRAMESIZE = tuple(metadata_dict["source_video_resolution"])
+FRAMERATE = metadata_dict["output_framerate"]
+FRAMESIZE = tuple(metadata_dict["output_frames_resolution"])
 
 # Define writer with parameters and suitable output filename for e.g. `output_foo.avi`
 writer = cv2.VideoWriter("output_foo.avi", FOURCC, FRAMERATE, FRAMESIZE)

--- a/docs/reference/ffdecoder/params.md
+++ b/docs/reference/ffdecoder/params.md
@@ -431,7 +431,7 @@ This parameter select the pixel format for output video frames _(such as `gray` 
 
 ??? note "Any invalid or unsupported value to `frame_format` parameter will discarded!"
 
-    Any improper `frame_format` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-pix_fmt` FFmpeg parameter value in Decoding pipeline uses `output_frames_pixfmt` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_resolution`  metadata property is found, then API finally defaults to **Default pixel-format**[^1] _(calculated variably)_.
+    Any improper `frame_format` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-pix_fmt` FFmpeg parameter value in Decoding pipeline uses `output_frames_pixfmt` metadata property extracted from Output Stream. Thereby, in case if no valid `output_frames_resolution`  metadata property is found, then API finally defaults to **Default pixel-format**[^1] _(calculated variably)_.
 
     !!! alert "The `output_frame_pixfmt` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
 
@@ -572,9 +572,9 @@ These parameters are discussed below:
 
         !!! alert "The `output_frames_framerate` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
 
-        Any improper `-framerate` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-framerate/-r` FFmpeg parameter value in Decoding pipeline uses `output_frames_framerate` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_framerate`  metadata property is found, then API finally defaults to `source_video_framerate` metadata property extracted from Input Source Stream.
+        Any improper `-framerate` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-framerate/-r` FFmpeg parameter value in Decoding pipeline uses `output_frames_framerate` metadata property extracted from Output Stream. Thereby, in case if no valid `output_framerate`  metadata property is found, then API finally defaults to `source_video_framerate` metadata property extracted from Input Source Stream.
 
-        !!! fail "In case neither `output_video_framerate` nor `source_video_framerate` valid metadata properties are found, then `RuntimeError` is raised."
+        !!! fail "In case neither `output_framerate` nor `source_video_framerate` valid metadata properties are found, then `RuntimeError` is raised."
 
     ??? info "Use `#!py3 {"-framerate":"null"}` in ffparams to discard `-framerate/-r` FFmpeg parameter entirely from Decoding pipeline."
 
@@ -593,9 +593,9 @@ These parameters are discussed below:
 
         !!! alert "The `output_frames_resolution` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
 
-        Any improper `-custom_resolution` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-s/-size` FFmpeg parameter value in Decoding pipeline uses `output_frames_resolution` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_resolution`  metadata property is found, then API finally defaults to `source_video_resolution` metadata property extracted from Input Source Stream.
+        Any improper `-custom_resolution` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-s/-size` FFmpeg parameter value in Decoding pipeline uses `output_frames_resolution` metadata property extracted from Output Stream. Thereby, in case if no valid `output_frames_resolution`  metadata property is found, then API finally defaults to `source_video_resolution` metadata property extracted from Input Source Stream.
 
-        !!! fail "In case neither `output_video_resolution` nor `source_video_resolution` valid metadata properties are found, then `RuntimeError` is raised."
+        !!! fail "In case neither `output_frames_resolution` nor `source_video_resolution` valid metadata properties are found, then `RuntimeError` is raised."
 
     ??? info "Use `#!py3 {"-custom_resolution":"null"}` in ffparams to discard `-size/-s` FFmpeg parameter entirely from Decoding pipeline."
 
@@ -668,8 +668,8 @@ These parameters are discussed below:
         - If `frame_format` parameter is valid and supported: Default pixel-format is `frame_format` parameter value.
         - If `frame_format` parameter is **NOT** valid or supported:
             - If `output_frame_pixfmt` metadata is available: Default pixel-format is `output_frame_pixfmt` metadata value.
-            - If `output_frame_pixfmt` metadata is **NOT** available: Default pixel-format is `rgb24` if supported otherwise `source_frame_pixfmt` metadata value.
-      - [x] If `frame_format == "null"`: Default pixel-format is `source_frame_pixfmt` metadata value
+            - If `output_frame_pixfmt` metadata is **NOT** available: Default pixel-format is `rgb24` if supported otherwise `source_video_pixfmt` metadata value.
+      - [x] If `frame_format == "null"`: Default pixel-format is `source_video_pixfmt` metadata value
 
 
 <!--

--- a/docs/reference/ffdecoder/params.md
+++ b/docs/reference/ffdecoder/params.md
@@ -427,22 +427,33 @@ decoder = FFdecoder("foo.mp4", source_demuxer="dshow").formulate()
 
 ## **`frame_format`** 
 
-This parameter select the pixel format for output video frames _(such as `gray` for grayscale output)_. If not specified, its value defaults to `rgb24` _(24-bit RGB)_.
+This parameter select the pixel format for output video frames _(such as `gray` for grayscale output)_.
 
-!!! warning "Any invalid or unsupported value to `frame_format` parameter will discarded!"
+??? note "Any invalid or unsupported value to `frame_format` parameter will discarded!"
 
-!!! tip "Use `#!sh ffmpeg -pix_fmts` terminal command to lists all FFmpeg supported pixel formats."
+    Any improper `frame_format` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-pix_fmt` FFmpeg parameter value in Decoding pipeline uses `output_frames_pixfmt` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_resolution`  metadata property is found, then API finally defaults to **Default pixel-format**[^1] _(calculated variably)_.
+
+    !!! alert "The `output_frame_pixfmt` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
+
+
+??? info "Use `#!py3 frame_format="null"` to manually discard `-pix_fmt` FFmpeg parameter entirely from Decoding pipeline."
+
+    This feature allows users to manually skip `-pix_fmt` FFmpeg parameter in Decoding pipeline, essentially for using only `format` filter values, or even better, let FFmpeg itself choose the best available output frame pixel-format for the given source.
+
 
 **Data-Type:** String
 
-**Default Value:** Its default value is `rgb24`
+**Default Value:** Its default value is **Default pixel-format**[^1] _(calculated variably)_.
 
 **Usage:**
+
 
 ```python
 # initialize and formulate the decoder for grayscale frames
 decoder = FFdecoder("foo.mp4", frame_format="gray").formulate()
 ```
+
+!!! tip "Use `#!sh ffmpeg -pix_fmts` terminal command to lists all FFmpeg supported pixel formats."
 
 !!! example "Various Pixel formats related usage recipes :material-pot-steam: can found [here ➶](../../../recipes/basic/decode-video-files/#capturing-and-previewing-bgr-frames-from-a-video-file)"
 
@@ -486,7 +497,7 @@ FFdecoder("foo.mp4", custom_ffmpeg="/foo/foo1/ffmpeg").formulate()
 
 ## **`verbose`**
 
-This parameter enables verbose _(if `True`)_, essential for debugging. 
+This parameter enables verbose logs _(if `True`)_, essential for debugging. 
 
 **Data-Type:** Boolean
 
@@ -495,6 +506,7 @@ This parameter enables verbose _(if `True`)_, essential for debugging.
 **Usage:**
 
 ```python
+# initialize and formulate decoder with verbose logs
 FFdecoder("foo.mp4", verbose=True).formulate()
 ```
 
@@ -534,16 +546,17 @@ decoder = FFdecoder("foo.mp4", verbose=True, **ffparams).formulate()
 
 #### B. Exclusive Parameters
 
-> In addition to FFmpeg parameters, FFdecoder API also supports few Exclusive Parameters, to allow users to flexibly change its internal pipeline, properties, and handle some special FFmpeg parameters _(such as repeated `map`)_ that cannot be assigned via. python dictionary. 
+> In addition to FFmpeg parameters, FFdecoder API also supports few Exclusive Parameters to allow users to flexibly change its internal pipeline, properties, and handle some special FFmpeg parameters _(such as repeated `map`)_ that cannot be assigned via. python dictionary. 
 
 These parameters are discussed below:
-
 
 * **`-vcodec`** _(str)_ : This attribute works similar to `-vcodec` FFmpeg parameter for specifying supported decoders that are compiled with FFmpeg in use. If not specified, it's value is derived from source video metadata. Its usage is as follows: 
 
     !!! tip "Use `#!sh ffmpeg -decoders` terminal command to lists all FFmpeg supported decoders."
 
-    !!! info "To remove `-vcodec` forcefully from FFmpeg Pipeline, assign its value Nonetype as `#!py3 {"-vcodec":None}` in ffparams"
+    ??? info "Use `#!py3 {"-vcodec":None}` in ffparams to discard `-vcodec` FFmpeg parameter entirely from Decoding pipeline."
+
+        This feature allows users to manually skip `-vcodec` FFmpeg parameter in Decoding pipeline, for letting FFmpeg itself choose the best available video decoder for the given source.
 
     ```python
     # define suitable parameter
@@ -553,7 +566,19 @@ These parameters are discussed below:
 &ensp;
 
 
-* **`-framerate`** _(float/int)_ : This attribute works similar to `-framerate` FFmpeg parameter for generating video-frames at specified framerate. If not specified, it calculated from source video metadata. Its usage is as follows: 
+* **`-framerate`** _(float/int)_ : This attribute works similar to `-framerate` FFmpeg parameter for generating video-frames at specified framerate. If not specified, it calculated from video metadata. Its usage is as follows: 
+
+    ??? note "Any invalid or unsupported value to `-framerate` attribute will discarded!"
+
+        !!! alert "The `output_frames_framerate` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
+
+        Any improper `-framerate` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-framerate/-r` FFmpeg parameter value in Decoding pipeline uses `output_frames_framerate` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_framerate`  metadata property is found, then API finally defaults to `source_video_framerate` metadata property extracted from Input Source Stream.
+
+        !!! fail "In case neither `output_video_framerate` nor `source_video_framerate` valid metadata properties are found, then `RuntimeError` is raised."
+
+    ??? info "Use `#!py3 {"-framerate":"null"}` in ffparams to discard `-framerate/-r` FFmpeg parameter entirely from Decoding pipeline."
+
+        This feature allows users to manually skip `-framerate/-r` FFmpeg parameter in Decoding pipeline, essentially for using only `fps` filter values, or even better, let FFmpeg itself choose the best available output framerate for the given source.
 
     ```python
     # define suitable parameter
@@ -562,7 +587,19 @@ These parameters are discussed below:
 
 &ensp;
 
-* **`-custom_resolution`** _(tuple/list)_ : This attribute sets the custom resolution/size/dimensions of the output frames. Its value can either be a **tuple** => `(width,height)` or a **list** => `[width, height]`. If not specified, it calculated from source video metadata. Its usage is as follows: 
+* **`-custom_resolution`** _(tuple/list)_ : This attribute sets the custom resolution/size of the output frames. Its value can either be a **tuple** (`(width,height)`) or a **list** (`[width, height]`). If not specified, it calculated from video metadata. Its usage is as follows: 
+
+    ??? note "Any invalid or unsupported value to `-custom_resolution` attribute will discarded!"
+
+        !!! alert "The `output_frames_resolution` metadata property is only available when FFmpeg filters via. `-vf` or `-filter_complex` are manually defined."
+
+        Any improper `-custom_resolution` parameter value _(i.e. either `null`(special-case), undefined, or invalid type)_ , then `-s/-size` FFmpeg parameter value in Decoding pipeline uses `output_frames_resolution` metadata property extracted from Output Stream. Thereby, in case if no valid `output_video_resolution`  metadata property is found, then API finally defaults to `source_video_resolution` metadata property extracted from Input Source Stream.
+
+        !!! fail "In case neither `output_video_resolution` nor `source_video_resolution` valid metadata properties are found, then `RuntimeError` is raised."
+
+    ??? info "Use `#!py3 {"-custom_resolution":"null"}` in ffparams to discard `-size/-s` FFmpeg parameter entirely from Decoding pipeline."
+
+        This feature allows users to manually skip `-size/-s` FFmpeg parameter in Decoding pipeline, essentially for using only `fps` filter values, or even better, let FFmpeg itself choose the best available output frames resolution for the given source.
     
     ```python
     # define suitable parameter
@@ -603,7 +640,7 @@ These parameters are discussed below:
 
 &ensp;
 
-* **`-custom_sourcer_params`** _(dict)_ :  This attribute assigns parameter meant for Sourcer API's [`sourcer_params`](../../sourcer/params/#sourcer_params) dictionary parameter, directly through FFdecoder API. Its usage is as follows: 
+* **`-custom_sourcer_params`** _(dict)_ :  This attribute assigns all [**Exclusive Parameter**](../../sourcer/params/#exclusive-parameters) meant for Sourcer API's `sourcer_params` dictionary parameter directly through FFdecoder API. Its usage is as follows: 
     
     ```python
     # define suitable parameter meant for `sourcer_params`
@@ -612,9 +649,28 @@ These parameters are discussed below:
 
 &ensp;
 
+* **`-default_stream_indexes`** _(list/tuple)_ : This attribute assign value directly to `default_stream_indexes` parameter in Sourcer API's [`probe_stream()`](../../../reference/sourcer/#deffcode.sourcer.Sourcer.probe_stream) method for selecting specific video and audio stream index in case of multiple ones. Value can be of format: `(int,int)` or `[int,int]` as follows:
+    
+    ```python
+    # define suitable parameter meant for `probe_stream()` method
+    ffparams = {"-default_stream_indexes": (0,1)} # ("0th video stream", "1st audio stream")
+    ```
+
+&ensp;
+
 * **`-passthrough_audio`** _(bool/list)_ : _(Yet to be supported)_
 
 &nbsp; 
+
+[^1]: **Default pixel-format** is calculated variably in FFdecoder API:
+      
+      - [x] If `frame_format != "null"`: 
+        - If `frame_format` parameter is valid and supported: Default pixel-format is `frame_format` parameter value.
+        - If `frame_format` parameter is **NOT** valid or supported:
+            - If `output_frame_pixfmt` metadata is available: Default pixel-format is `output_frame_pixfmt` metadata value.
+            - If `output_frame_pixfmt` metadata is **NOT** available: Default pixel-format is `rgb24` if supported otherwise `source_frame_pixfmt` metadata value.
+      - [x] If `frame_format == "null"`: Default pixel-format is `source_frame_pixfmt` metadata value
+
 
 <!--
 External URLs

--- a/docs/reference/sourcer/params.md
+++ b/docs/reference/sourcer/params.md
@@ -375,7 +375,7 @@ Sourcer("foo.mp4", custom_ffmpeg="/foo/foo1/ffmpeg").probe_stream()
 
 ## **`verbose`**
 
-This parameter enables verbose _(if `True`)_, essential for debugging. 
+This parameter enables verbose logs _(if `True`)_, essential for debugging. 
 
 **Data-Type:** Boolean
 
@@ -384,6 +384,7 @@ This parameter enables verbose _(if `True`)_, essential for debugging.
 **Usage:**
 
 ```python
+# initialize the sourcer with verbose logs
 Sourcer("foo.mp4", verbose=True).probe_stream()
 ```
 
@@ -394,48 +395,23 @@ Sourcer("foo.mp4", verbose=True).probe_stream()
 
 This dictionary parameter accepts all [Exclusive Parameters](#exclusive-parameters) formatted as its attributes:
 
+???+ note "Additional FFmpeg parameters"
+    
+    In addition to Exclusive Parameters, Sourcer API supports almost any FFmpeg parameter _(supported by installed FFmpeg)_, and thereby can be passed as dictionary attributes in `sourcer_params` parameter.
+
+    !!! danger "Kindly read [**FFmpeg Docs**](https://ffmpeg.org/documentation.html) carefully before passing any additional values to `sourcer_params` parameter. Wrong invalid values may result in undesired errors or no output at all."
+
+    !!! alert "All FFmpeg parameters are case-sensitive. Remember to double check every parameter if any error(s) occurred."
+
 **Data-Type:** Dictionary
 
 **Default Value:** Its default value is `{}`.
 
 ### Exclusive Parameters
 
-> In addition to FFmpeg parameters, Sourcer API also supports few Exclusive Parameters, to allow users to flexibly change its probing properties, and handle some special FFmpeg parameters.
+> Sourcer API supports few Exclusive Parameters to allow users to flexibly change its probing properties and handle some special FFmpeg parameters.
 
 These parameters are discussed below:
-
-
-* **`-vcodec`** _(str)_ : This attribute works similar to `-vcodec` FFmpeg parameter for specifying supported decoders that are compiled with FFmpeg in use. If not specified, it's value is derived from source video metadata. Its usage is as follows: 
-
-    !!! tip "Use `#!sh ffmpeg -decoders` terminal command to lists all FFmpeg supported decoders."
-
-    !!! info "To remove `-vcodec` forcefully from FFmpeg Pipeline, assign its value Nonetype as `#!py3 {"-vcodec":None}` in sourcer_params"
-
-    ```python
-    # define suitable parameter
-    sourcer_params = {"-vcodec": "h264"} # set decoder to `h264`
-    ```
-
-&ensp;
-
-
-* **`-framerate`** _(float/int)_ : This attribute works similar to `-framerate` FFmpeg parameter for generating video-frames at specified framerate. If not specified, it calculated from source video metadata. Its usage is as follows: 
-
-    ```python
-    # define suitable parameter
-    sourcer_params = {"-framerate": 60.0} # set input video source framerate to 60fps
-    ```
-
-&ensp;
-
-* **`-custom_resolution`** _(tuple/list)_ : This attribute sets the custom resolution/size/dimensions of the output frames. Its value can either be a **tuple** => `(width,height)` or a **list** => `[width, height]`. If not specified, it calculated from source video metadata. Its usage is as follows: 
-    
-    ```python
-    # define suitable parameter
-    sourcer_params = {"-output_dimensions": (1280,720)} # to produce a 1280x720 resolution/scale output video
-    ```
-
-&ensp;
 
 * **`-ffprefixes`** _(list)_: This attribute sets the special FFmpeg parameters that generally occurs at the very beginning _(such as `-re`)_ before input (`-i`) source. The FFmpeg parameters defined with this attribute can repeated more than once and maintains its original order in the FFmpeg command. Its value can be of datatype **`list`** only and its usage is as follows: 
 

--- a/tests/test_ffdecoder.py
+++ b/tests/test_ffdecoder.py
@@ -522,9 +522,9 @@ def test_discard_n_filter_params(frame_format, ffparams, result):
             )
             # assign manually pix-format via `metadata` property object {special case}
             decoder.metadata = (
-                {"source_video_resolution": [0], "output_video_resolution": [0]}
+                {"source_video_resolution": [0], "output_frames_resolution": [0]}
                 if frame_format == "invalid2"
-                else {"source_video_framerate": 0.0, "output_video_framerate": 0.0}
+                else {"source_video_framerate": 0.0, "output_framerate": 0.0}
             )
             # formulate decoder
             decoder.formulate()

--- a/tests/test_ffdecoder.py
+++ b/tests/test_ffdecoder.py
@@ -313,7 +313,7 @@ def test_seek_n_save(ffparams, pixfmts):
         filename and remove_file_safe(filename)
 
 
-test_data_class = [
+test_data = [
     (return_testvideo_path(), {"-c:v": "hevc"}, False),
     (
         return_generated_frames_path(return_static_ffmpeg()),
@@ -340,7 +340,7 @@ test_data_class = [
 ]
 
 
-@pytest.mark.parametrize("source, ffparams, result", test_data_class)
+@pytest.mark.parametrize("source, ffparams, result", test_data)
 def test_FFdecoder_params(source, ffparams, result):
     """
     Testing FFdecoder API with different parameters and save output
@@ -391,7 +391,7 @@ def test_FFdecoder_params(source, ffparams, result):
             remove_file_safe(f_name)
 
 
-test_data_class = [
+test_data = [
     (
         "/dev/video0",
         "v4l2",
@@ -413,7 +413,7 @@ test_data_class = [
 ]
 
 
-@pytest.mark.parametrize("source, source_demuxer, result", test_data_class)
+@pytest.mark.parametrize("source, source_demuxer, result", test_data)
 def test_camera_capture(source, source_demuxer, result):
     """
     Tests FFdecoder's realtime Webcam and Virtual playback capabilities
@@ -428,8 +428,108 @@ def test_camera_capture(source, source_demuxer, result):
             frame_format="bgr24",
             verbose=True,
         ).formulate()
-        # capture 10 camera frames
-        for i in range(10):
+        # capture 5 camera frames
+        for i in range(5):
+            # grab the bgr24 frame from the decoder
+            frame_recv = next(decoder.generateFrame(), None)
+            # check if frame is None
+            if frame_recv is None:
+                raise AssertionError("Test Failed!")
+    except Exception as e:
+        if result:
+            # catch errors
+            pytest.fail(str(e))
+        else:
+            pytest.xfail(str(e))
+    finally:
+        # terminate
+        not (decoder is None) and decoder.terminate()
+
+
+test_data = [
+    (
+        "null",  # discard frame_format
+        {
+            "-custom_resolution": "null",  # discard `-custom_resolution`
+            "-framerate": "null",  # discard `-framerate`
+            "-vf": "format=bgr24,scale=320:240,fps=60",  # format=bgr24, scale=320x240, framerate=60fps
+        },
+        True,
+    ),
+    (
+        "bgr24",  # this pixel-format must override filter `format=rgb24`
+        {
+            "-vf": "format=rgb24,scale=320:240,fps=60",  # format=rgb24, scale=320x240, framerate=60fps
+        },
+        True,
+    ),
+    (
+        "invalid",  # invalid frame_format
+        {
+            "-custom_resolution": "invalid",  # invalid `-custom_resolution`
+            "-framerate": "invalid",  # invalid `-framerate`
+            "-vf": "format=bgr24,scale=320:240,fps=60",  # format=bgr24, scale=320x240, framerate=60fps
+        },
+        True,
+    ),
+    (
+        "invalid2",  # invalid frame_format
+        {
+            "-custom_resolution": "invalid",  # invalid `-custom_resolution`
+            "-framerate": "null",  # discard `-framerate`
+        },
+        False,
+    ),
+    (
+        "invalid3",  # invalid frame_format
+        {
+            "-custom_resolution": "null",  # discard `-custom_resolution`
+            "-framerate": "invalid",  # invalid `-framerate`
+        },
+        False,
+    ),
+    (
+        "null",  # discard frame_format
+        {
+            "-custom_resolution": "null",  # discard `-custom_resolution`
+            "-framerate": "null",  # discard `-framerate`
+        },
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize("frame_format, ffparams, result", test_data)
+def test_discard_n_filter_params(frame_format, ffparams, result):
+    """
+    Tests FFdecoder's discarding FFmpeg parameters and using FFmpeg Filter
+    capabilities
+    """
+    decoder = None
+    try:
+        # initialize and formulate the decode with suitable source
+        if not frame_format in ["invalid2", "invalid3"]:
+            decoder = FFdecoder(
+                return_testvideo_path(),
+                frame_format=frame_format,
+                verbose=True,
+            ).formulate()
+        else:
+            decoder = FFdecoder(
+                return_testvideo_path(),
+                frame_format=frame_format,
+                verbose=True,
+            )
+            # assign manually pix-format via `metadata` property object {special case}
+            decoder.metadata = (
+                {"source_video_resolution": [0], "output_video_resolution": [0]}
+                if frame_format == "invalid2"
+                else {"source_video_framerate": 0.0, "output_video_framerate": 0.0}
+            )
+            # formulate decoder
+            decoder.formulate()
+        # capture 2 camera frames
+        for i in range(2):
             # grab the bgr24 frame from the decoder
             frame_recv = next(decoder.generateFrame(), None)
             # check if frame is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ from os.path import expanduser
 from deffcode.utils import dict2Args, logger_handler, delete_file_safe
 
 # define test logger
-logger = logging.getLogger("Test_utils")
+logger = logging.getLogger("Test_Utilities")
 logger.propagate = False
 logger.addHandler(logger_handler())
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
This PR will implement new comprehensive support for both discarding key default FFmpeg parameters from Decoding pipeline simply by assigning them `null` string values, and concurrently using values extracted from Output Stream metadata properties _(available only when FFmpeg filters are defined)_ for formulating Pipeline.


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the DeFFcode [PR Guidelines](https://abhitronix.github.io/deffcode/latest/contribution/PR/).
- [x] I have read the DeFFcode [Documentation](https://abhitronix.github.io/deffcode/latest).
- [x] I have updated the documentation files accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#31 #30

### Context
<!--- Why is this change required? What problem does it solve? -->
Both Discarding default FFmpeg parameters and using FFmpeg Filters, are absolute necessity for decoding/transcoding video frames in GPU, as with FFmpeg commands like `ffmpeg -y -vsync 0 -hwaccel_output_format cuda -hwaccel cuda -c:v h264_cuvid -i input.mp4 -vf "scale_npp=format=yuv420p,hwdownload,format=yuv420p,fps=25.0" -f rawvideo -` fails to work with FFmpeg parameters `-framerate`, `-pix_fmt`, `-size`  and throws `Impossible to convert between the formats supported by the filter 'Parsed_null_0' and the filter 'auto_scale_0' Error reinitializing filters! Failed to inject frame into filter network: Function not implemented` error. **Therefore, implementing both these features will resolves issue with decoding/transcoding with DeFFcode APIs automatically _(thus resolving #30)_.**


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Miscellaneous (if available):
<!-- Provide any screenshots or any Miscellaneous info if available or else remove this block -->
Bare-minimum Code to test this PR features:
```python
# import the necessary packages
from deffcode import FFdecoder
import cv2

# define params and custom filters
ffparams = {
    "-custom_resolution": "null",  # discard `-custom_resolution`
    "-framerate": "null",  # discard `-framerate`
    "-vf": "format=bgr24,scale=320:240,fps=60",  # format=bgr24, scale=320x240, framerate=60fps
}

# initialize and formulate the decoder with params and custom filters
decoder = FFdecoder(
    "t.mp4", frame_format="null", verbose=True, **ffparams  # discard frame_format
).formulate()

# grab the BGR24 frames from decoder
for frame in decoder.generateFrame():

    # check if frame is None
    if frame is None:
        break

    # {do something with the frame here}

    # Show output window
    cv2.imshow("Output", frame)

    # check for 'q' key if pressed
    key = cv2.waitKey(1) & 0xFF
    if key == ord("q"):
        break

# close output window
cv2.destroyAllWindows()

# terminate the decoder
decoder.terminate()
```