### PR TITLE
✨ FFdecoder: Introduced a new optional -disable_ffmpeg_window boolean parameter. (Fixes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,18 +310,18 @@ It is something I am doing with my own free time. But so much more needs to be d
 
 Here is a Bibtex entry you can use to cite this project in a publication:
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7155399.svg)](https://doi.org/10.5281/zenodo.7155399)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7523792.svg)](https://doi.org/10.5281/zenodo.7523792)
 
 ```BibTeX
 @software{deffcode,
-  author       = {Abhishek Singh Thakur},
-  title        = {abhiTronix/deffcode: v0.2.4},
-  month        = oct,
-  year         = 2022,
+  author       = {Abhishek Thakur},
+  title        = {abhiTronix/deffcode: v0.2.5},
+  month        = jan,
+  year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.2.4},
-  doi          = {10.5281/zenodo.7155399},
-  url          = {https://doi.org/10.5281/zenodo.7155399}
+  version      = {v0.2.5},
+  doi          = {10.5281/zenodo.7523792},
+  url          = {https://doi.org/10.5281/zenodo.7523792}
 }
 ```
 

--- a/deffcode/ffhelper.py
+++ b/deffcode/ffhelper.py
@@ -683,7 +683,7 @@ def check_sp_output(*args, **kwargs):
     retcode = process.poll()
     # handle return code
     if retcode and not (retrieve_stderr):
-        logger.error("[Pipline-Error] :: {}".format(output.decode("utf-8")))
+        logger.error("[Pipeline-Error] :: {}".format(output.decode("utf-8")))
         cmd = kwargs.get("args")
         if cmd is None:
             cmd = args[0]
@@ -692,7 +692,7 @@ def check_sp_output(*args, **kwargs):
         raise error
     # raise error if no output
     bool(output) or bool(stderr) or logger.error(
-        "[Pipline-Error] :: Pipline failed to exact any data from command: {}!".format(
+        "[Pipeline-Error] :: Pipeline failed to exact any data from command: {}!".format(
             args[0] if args else []
         )
     )

--- a/deffcode/sourcer.py
+++ b/deffcode/sourcer.py
@@ -87,7 +87,7 @@ class Sourcer:
             verbose (bool): enables/disables verbose.
             sourcer_params (dict): provides the flexibility to control supported internal and FFmpeg parameters.
         """
-        # checks if machine in-use is running windows os or not
+        # checks machine OS
         self.__machine_OS = platform.system()
 
         # define internal parameters

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,18 +197,18 @@ It is something I am doing with my own free time. But so much more needs to be d
 
 Here is a Bibtex entry you can use to cite this project in a publication:
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7155399.svg)](https://doi.org/10.5281/zenodo.7155399)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7523792.svg)](https://doi.org/10.5281/zenodo.7523792)
 
 ```BibTeX
 @software{deffcode,
-  author       = {Abhishek Singh Thakur},
-  title        = {abhiTronix/deffcode: v0.2.4},
-  month        = oct,
-  year         = 2022,
+  author       = {Abhishek Thakur},
+  title        = {abhiTronix/deffcode: v0.2.5},
+  month        = jan,
+  year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.2.4},
-  doi          = {10.5281/zenodo.7155399},
-  url          = {https://doi.org/10.5281/zenodo.7155399}
+  version      = {v0.2.5},
+  doi          = {10.5281/zenodo.7523792},
+  url          = {https://doi.org/10.5281/zenodo.7523792}
 }
 ```
 

--- a/docs/reference/ffdecoder/params.md
+++ b/docs/reference/ffdecoder/params.md
@@ -729,6 +729,17 @@ These parameters are discussed below:
 
 &ensp;
 
+* **`-disable_ffmpeg_window`** _(bool)_: This attribute can be used to prevent the FFmpeg command line window from appearing when using the FFdecoder API on Windows. This is especially useful when creating an `.exe` file for your Python script with logging disabled(`verbose=False`), as it stops the FFmpeg window from popping up even in windowed or no-console mode. Its usage is as follows:
+
+    !!! warning "The `-disable_ffmpeg_window` flag is only available on :fontawesome-brands-windows: Windows OS with logging disabled."
+
+    ```python
+    # define suitable parameter
+    ffparams = {"-disable_ffmpeg_window": True} # disables FFmpeg creation window
+    ```
+
+&ensp;
+
 * **`-passthrough_audio`** _(bool/list)_ : _(Yet to be supported)_
 
 &nbsp; 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,10 @@ extra_css:
 extra_javascript:
   - assets/javascripts/extra.js
 
+# Logging
+validation:
+  unrecognized_links: ignore
+
 # Extensions
 markdown_extensions:
   - admonition

--- a/tests/test_ffdecoder.py
+++ b/tests/test_ffdecoder.py
@@ -185,11 +185,12 @@ def test_frame_format(pixfmts):
                 ),
                 "output_frames_pixfmt": 1234,  # invalid pixformat
                 "source_video_resolution": [640],  # invalid resolution
+                "-disable_ffmpeg_window": "Invalid",
             },
             False,
         ),
         (
-            {"output_frames_pixfmt": "invalid"},
+            {"output_frames_pixfmt": "invalid", "-disable_ffmpeg_window": False},
             False,
         ),
         (["invalid"], False),
@@ -216,7 +217,11 @@ def test_metadata(custom_params, checks):
     source = return_testvideo_path(fmt="vo")
     try:
         # custom vars
-        ffparams = {"-framerate": None} if not checks else {"-framerate": 25.0}
+        ffparams = (
+            {"-framerate": None}
+            if not checks
+            else {"-framerate": 25.0, "-disable_ffmpeg_window": True}
+        )
         # formulate the decoder with suitable source(for e.g. foo.mp4)
         decoder = FFdecoder(
             source, custom_ffmpeg=return_static_ffmpeg(), verbose=True, **ffparams


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
This PR introduces a new optional -disable_ffmpeg_window boolean parameter to prevents the FFmpeg command line window from appearing by applying `DETACHED_PROCESS` flag to subprocess FFmpeg pipeline when building `.exe` files on Windows in silent (`verbose=False`) mode.


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the DeFFcode [PR Guidelines](https://abhitronix.github.io/deffcode/latest/contribution/PR/).
- [x] I have read the DeFFcode [Documentation](https://abhitronix.github.io/deffcode/latest).
- [x] I have updated the documentation files accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#42

### Context
<!--- Why is this change required? What problem does it solve? -->
This PR is specifically aimed at improving the user experience when building .exe files on Windows in silent (verbose=False) mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Miscellaneous (if available):
<!-- Provide any screenshots or any Miscellaneous info if available or else remove this block -->
None