### PR TITLE
57 bug high cpu usage when chaining ffdecoder with writegear

### DIFF
--- a/.github/workflows/docs_deployer.yml
+++ b/.github/workflows/docs_deployer.yml
@@ -34,10 +34,10 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install_deffcode
@@ -48,8 +48,7 @@ jobs:
       - name: install_docs_deps
         run: |
           pip install -U mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-minify-plugin          
-          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python-legacy
-          pip install jinja2==3.0.*
+          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python
         if: success()
       - name: git configure
         run: |
@@ -82,10 +81,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install_deffcode
@@ -96,8 +95,7 @@ jobs:
       - name: install_docs_deps
         run: |
           pip install -U mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-minify-plugin          
-          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python-legacy
-          pip install jinja2==3.0.*
+          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python
         if: success()
       - name: git configure
         run: |
@@ -131,11 +129,11 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: git checkout dev
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install_deffcode
@@ -146,8 +144,7 @@ jobs:
       - name: install_docs_deps
         run: |
           pip install -U mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-minify-plugin          
-          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python-legacy
-          pip install jinja2==3.0.*
+          pip install -U mkdocs-exclude mike mkdocstrings mkdocstrings-python
         if: success()
       - name: git configure
         run: |

--- a/deffcode/sourcer.py
+++ b/deffcode/sourcer.py
@@ -331,7 +331,7 @@ class Sourcer:
 
         Parameters:
             pretty_json (bool): whether to return metadata as JSON string(if `True`) or Dictionary(if `False`) type?
-            force_retrieve_output (bool): whether to also return metadata missing in current Pipeline. This method returns `(metadata, metadata_missing)` tuple if `force_retrieve_output=True` instead of `metadata`.
+            force_retrieve_missing (bool): whether to also return metadata missing in current Pipeline. This method returns `(metadata, metadata_missing)` tuple if `force_retrieve_missing=True` instead of `metadata`.
 
         **Returns:** `metadata` or `(metadata, metadata_missing)`, formatted as JSON string or python dictionary.
         """

--- a/docs/recipes/advanced/decode-live-virtual-sources.md
+++ b/docs/recipes/advanced/decode-live-virtual-sources.md
@@ -22,7 +22,7 @@ limitations under the License.
 
 > Instead of using prerecorded video files as streams, DeFFcode's FFdecoder API with the help of powerful [`lavfi`](http://underpop.online.fr/f/ffmpeg/help/lavfi.htm.gz) _(**Libavfilter** input virtual device)_ source that reads data from the open output pads of a libavfilter filtergraph, is also capable of creating virtual video frames out of thin air in real-time, which you might want to use as input for testing, compositing, and merging with other streams to obtain desired output on-the-fly. 
 
-We'll discuss the recipies for generating Live Fake Sources briefly below:
+We'll discuss the recipes for generating Live Fake Sources briefly below:
 
 &thinsp;
 
@@ -65,7 +65,7 @@ We'll discuss the recipies for generating Live Fake Sources briefly below:
 > The [`sierpinski`](https://ffmpeg.org/ffmpeg-filters.html#toc-sierpinski) graph generates a Sierpinski carpet/triangle fractal, and randomly pan around by a single pixel each frame.
 
 <figure markdown>
-  ![sierpinski pattern](../../../assets/gifs/sierpinski.gif){ width="500" }
+  ![sierpinski pattern](../../assets/gifs/sierpinski.gif){ width="500" }
   <figcaption>Sierpinski carpet fractal</figcaption>
 </figure>
 
@@ -122,7 +122,7 @@ decoder.terminate()
 > The [`testsrc`](https://ffmpeg.org/ffmpeg-filters.html#toc-allrgb_002c-allyuv_002c-color_002c-colorchart_002c-colorspectrum_002c-haldclutsrc_002c-nullsrc_002c-pal75bars_002c-pal100bars_002c-rgbtestsrc_002c-smptebars_002c-smptehdbars_002c-testsrc_002c-testsrc2_002c-yuvtestsrc) graph generates a test video pattern showing a color pattern, a scrolling gradient, and a timestamp. This is useful for testing purposes.
 
 <figure markdown>
-  ![testsrc pattern](../../../assets/gifs/testsrc.gif){ width="500" }
+  ![testsrc pattern](../../assets/gifs/testsrc.gif){ width="500" }
   <figcaption>Test Source pattern</figcaption>
 </figure>
 
@@ -181,7 +181,7 @@ decoder.terminate()
 > The [`gradients`](https://ffmpeg.org/ffmpeg-filters.html#toc-gradients) graph (as name suggests) generates several random gradients.
 
 <figure markdown>
-  ![gradients test pattern](../../../assets/gifs/gradients.gif){ width="500" }
+  ![gradients test pattern](../../assets/gifs/gradients.gif){ width="500" }
   <figcaption>Gradients pattern with real-time text output</figcaption>
 </figure>
 
@@ -249,7 +249,7 @@ decoder.terminate()
 > The [`mandelbrot`](https://ffmpeg.org/ffmpeg-filters.html#toc-mandelbrot) graph generate a [**Mandelbrot set fractal**](https://en.wikipedia.org/wiki/Mandelbrot_set), that progressively zoom towards a specfic point.
 
 <figure markdown>
-  ![mandelbrot test pattern](../../../assets/gifs/mandelbrot_vectorscope_waveforms.gif){ width="500" }
+  ![mandelbrot test pattern](../../assets/gifs/mandelbrot_vectorscope_waveforms.gif){ width="500" }
   <figcaption>Mandelbrot pattern with a Vectorscope & two Waveforms</figcaption>
 </figure>
 
@@ -316,7 +316,7 @@ decoder.terminate()
 > The [`life`](https://ffmpeg.org/ffmpeg-filters.html#toc-life) graph generates a life pattern based on a generalization of John Conway’s life game. The sourced input represents a life grid, each pixel represents a cell which can be in one of two possible states, alive or dead. Every cell interacts with its eight neighbours, which are the cells that are horizontally, vertically, or diagonally adjacent. At each interaction the grid evolves according to the adopted rule, which specifies the number of neighbor alive cells which will make a cell stay alive or born.
 
 <figure markdown>
-  ![life pattern](../../../assets/gifs/life.gif){ width="500" }
+  ![life pattern](../../assets/gifs/life.gif){ width="500" }
   <figcaption>Game of Life Visualization</figcaption>
 </figure>
 

--- a/docs/recipes/advanced/transcode-art-filtergraphs.md
+++ b/docs/recipes/advanced/transcode-art-filtergraphs.md
@@ -28,7 +28,7 @@ limitations under the License.
 
     They can be processed by simply inserting an additional step between decoding and encoding of video frames:
 
-    ![Simple filtergraphs](../../../assets/images/simplefiltergraphs.png){ loading=lazy }
+    ![Simple filtergraphs](../../assets/images/simplefiltergraphs.png){ loading=lazy }
 
     Simple filtergraphs are configured with the per-stream `-filter` option _(with `-vf` for video)_. 
 
@@ -84,7 +84,7 @@ We'll discuss the Transcoding Video Art with Filtergraphs in the following recip
 > Based on the QCTools bitplane visualization, this video art has numerical values ranging between `-1`(no change) and `10`(noisiest) for the `Y` _(luminance)_, `U` and `V` _(chroma or color difference)_ planes, yielding cool and different results for different values.
 
 <figure markdown>
-  ![Bitplane Visualization](../../../assets/gifs/bitplane_visualization.gif)
+  ![Bitplane Visualization](../../assets/gifs/bitplane_visualization.gif)
   <figcaption>YUV Bitplane Visualization</figcaption>
 </figure>
 
@@ -155,7 +155,7 @@ writer.close()
 > This video art uses FFmpeg's [`pseudocolor`](https://ffmpeg.org/ffmpeg-filters.html#toc-pseudocolor) filter to create a **Jetcolor effect** which is high contrast, high brightness, and high saturation colormap that ranges from blue to red, and passes through the colors cyan, yellow, and orange. The jet colormap is associated with an astrophysical fluid jet simulation from the National Center for Supercomputer Applications. 
 
 <figure markdown>
-  ![Jetcolor effect](../../../assets/gifs/jetcolor_effect.gif)
+  ![Jetcolor effect](../../assets/gifs/jetcolor_effect.gif)
   <figcaption>Jetcolor effect</figcaption>
 </figure>
 
@@ -232,7 +232,7 @@ writer.close()
 > This video art using FFmpeg’s [`lagfun`](https://ffmpeg.org/ffmpeg-filters.html#toc-lagfun) filter to create a video echo/ghost/trailing effect.
 
 <figure markdown>
-  ![Ghosting effect](../../../assets/gifs/ghosting_effect.gif)
+  ![Ghosting effect](../../assets/gifs/ghosting_effect.gif)
   <figcaption>Ghosting effect</figcaption>
 </figure>
 
@@ -300,7 +300,7 @@ writer.close()
 > This video art uses FFmpeg’s `overlay`, `smartblur` and stacks of `dilation` filters to intentionally Pixelate your video in artistically cool looking ways such that each pixel become visible to the naked eye.
 
 <figure markdown>
-  ![Pixelation effect](../../../assets/gifs/pixelation_effect.gif)
+  ![Pixelation effect](../../assets/gifs/pixelation_effect.gif)
   <figcaption>Pixelation effect</figcaption>
 </figure>
 

--- a/docs/recipes/advanced/transcode-hw-acceleration.md
+++ b/docs/recipes/advanced/transcode-hw-acceleration.md
@@ -36,14 +36,14 @@ limitations under the License.
     As we know, using the `–hwaccel cuda -hwaccel_output_format cuda` flags in FFmpeg pipeline will keep video frames in GPU memory, and this ensures that the memory transfers (system memory to video memory and vice versa) are eliminated, and that transcoding is performed with the highest possible performance on the available GPU hardware.
 
     <figure markdown>
-      ![HW Acceleration](../../../assets/images/hw_accel.png){ width="350" }
+      ![HW Acceleration](../../assets/images/hw_accel.png){ width="350" }
       <figcaption>General Memory Flow with Hardware Acceleration</figcaption>
     </figure>
     
     But unfortunately, for processing real-time frames in our python script with FFdecoder and WriteGear APIs, we're bound to sacrifice this performance gain by explicitly copying raw decoded frames between System and GPU memory _(via the PCIe bus)_, thereby creating self-made latency in transfer time and increasing PCIe bandwidth occupancy due to overheads in communication over the bus. Moreover, given PCIe bandwidth limits, copying uncompressed image data would quickly saturate the PCIe bus. 
 
     <figure markdown>
-      ![HW Acceleration Limitation](../../../assets/images/hw_accel_limitation.png){ width="350" }
+      ![HW Acceleration Limitation](../../assets/images/hw_accel_limitation.png){ width="350" }
       <figcaption>Memory Flow with Hardware Acceleration <br>and Real-time Processing</figcaption>
     </figure>
 

--- a/docs/recipes/advanced/transcode-live-frames-complexgraphs.md
+++ b/docs/recipes/advanced/transcode-live-frames-complexgraphs.md
@@ -80,7 +80,7 @@ We'll discuss the transcoding of live complex filtergraphs in the following reci
 ## Transcoding video with Live Custom watermark image overlay
 
 <figure markdown>
-  ![Big Buck Bunny with watermark](../../../assets/gifs/watermark_overlay.gif)
+  ![Big Buck Bunny with watermark](../../assets/gifs/watermark_overlay.gif)
   <figcaption>Big Buck Bunny with custom watermark</figcaption>
 </figure>
 
@@ -153,7 +153,7 @@ writer.close()
 ## Transcoding video from sequence of Images with additional filtering
 
 <figure markdown>
-  ![mandelbrot test pattern](../../../assets/gifs/fish_mandelbrot.gif)
+  ![mandelbrot test pattern](../../assets/gifs/fish_mandelbrot.gif)
   <figcaption>Mandelbrot pattern blend with Fish school video</figcaption>
 </figure>
 

--- a/docs/recipes/basic/transcode-live-frames-simplegraphs.md
+++ b/docs/recipes/basic/transcode-live-frames-simplegraphs.md
@@ -28,7 +28,7 @@ limitations under the License.
 
     They can be processed by simply inserting an additional step between decoding and encoding of video frames:
 
-    ![Simple filtergraphs](../../../assets/images/simplefiltergraphs.png){ loading=lazy }
+    ![Simple filtergraphs](../../assets/images/simplefiltergraphs.png){ loading=lazy }
 
     Simple filtergraphs are configured with the per-stream `-filter` option _(with `-vf` for video)_. 
 
@@ -74,7 +74,7 @@ We'll discuss the transcoding of live simple filtergraphs in the following recip
 ## Transcoding Trimmed and Reversed video
 
 <figure markdown>
-  ![Big Buck Bunny Reversed](../../../assets/gifs/bigbuckbunny_reversed.gif)
+  ![Big Buck Bunny Reversed](../../assets/gifs/bigbuckbunny_reversed.gif)
   <figcaption>Big Buck Bunny Reversed</figcaption>
 </figure>
 
@@ -140,7 +140,7 @@ writer.release()
 ## Transcoding Cropped video
 
 <figure markdown>
-  ![Big Buck Bunny Cropped](../../../assets/gifs/bigbuckbunny_cropped.gif)
+  ![Big Buck Bunny Cropped](../../assets/gifs/bigbuckbunny_cropped.gif)
   <figcaption>Big Buck Bunny Cropped</figcaption>
 </figure>
 
@@ -206,7 +206,7 @@ writer.release()
 !!! quote "FFmpeg features **Rotate** Filter that is used to rotate videos by an arbitrary angle (expressed in radians)."
 
 <figure markdown>
-  ![Big Buck Bunny Rotated](../../../assets/gifs/bigbuckbunny_rotate.gif)
+  ![Big Buck Bunny Rotated](../../assets/gifs/bigbuckbunny_rotate.gif)
   <figcaption>Big Buck Bunny Rotated (with <code>rotate</code> filter)</figcaption>
 </figure>
 
@@ -270,7 +270,7 @@ writer.release()
 !!! quote "FFmpeg also features **Transpose** Filter that is used to rotate videos by 90 degrees clockwise and counter-clockwise direction as well as flip them vertically and horizontally."
 
 <figure markdown>
-  ![Big Buck Bunny Rotated](../../../assets/gifs/bigbuckbunny_transpose.gif)
+  ![Big Buck Bunny Rotated](../../assets/gifs/bigbuckbunny_transpose.gif)
   <figcaption>Big Buck Bunny Rotated (with <code>transpose</code> filter)</figcaption>
 </figure>
 
@@ -331,7 +331,7 @@ writer.release()
 ## Transcoding Horizontally flipped and Scaled video
 
 <figure markdown>
-  ![Big Buck Bunny Horizontally flipped and Scaled](../../../assets/gifs/bigbuckbunny_hflip_scaled.gif)
+  ![Big Buck Bunny Horizontally flipped and Scaled](../../assets/gifs/bigbuckbunny_hflip_scaled.gif)
   <figcaption>Big Buck Bunny Horizontally flipped and Scaled</figcaption>
 </figure>
 

--- a/docs/recipes/basic/transcode-live-frames.md
+++ b/docs/recipes/basic/transcode-live-frames.md
@@ -79,11 +79,11 @@ We'll discuss transcoding using both these libraries briefly in the following re
 
 &thinsp;
 
-## Transcoding video using OpenCV VideoWriter API
+## Transcoding Video using OpenCV VideoWriter API
 
-!!! quote "OpenCV's' [`VideoWriter()`](https://docs.opencv.org/3.4/dd/d9e/classcv_1_1VideoWriter.html#ad59c61d8881ba2b2da22cff5487465b5) class can be used directly with DeFFcode's FFdecoder API to encode video frames into a multimedia video file but it lacks the ability to control output quality, bitrate, compression, and other important features which are only available with VidGear's WriteGear API."
+OpenCV's [`VideoWriter()`](https://docs.opencv.org/3.4/dd/d9e/classcv_1_1VideoWriter.html#ad59c61d8881ba2b2da22cff5487465b5) class can be used directly with DeFFcode's FFdecoder API to encode video frames into a multimedia file. However, it lacks fine-grained control over output quality, bitrate, compression, and other advanced parameters—features that are readily available with VidGear's WriteGear API.
 
-In this example we will decode different pixel formats video frames from a given Video file _(say `foo.mp4`)_ in FFdecoder API, and encode them using OpenCV Library's `VideoWriter()` method in real-time. 
+In this example, we will decode video frames with different pixel formats from a given video file *(e.g., `foo.mp4`)* using the FFdecoder API, and then encode them in real time using OpenCV's `VideoWriter()` method.. 
 
 !!! info "OpenCV's `VideoWriter()` class requires a valid Output filename _(e.g. output_foo.avi)_, [FourCC](https://www.fourcc.org/fourcc.php) code, framerate, and resolution as input."
 
@@ -317,14 +317,12 @@ In this example we will decode different pixel formats video frames from a given
 
     !!! tip "Hardware Acceleration"
         If your machine has a dedicated GPU, you can offload encoding to the GPU entirely — for example by passing `"-vcodec": "h264_nvenc"` to WriteGear _(NVIDIA)_ — shifting the heavy lifting off the CPU.
-
-???+ quote "Lossless transcoding  with FFdecoder and WriteGear API"
     
-    VidGear's [**WriteGear API**](https://abhitronix.github.io/vidgear/latest/gears/writegear/introduction/) implements a complete, flexible, and robust wrapper around FFmpeg in [compression mode](https://abhitronix.github.io/vidgear/latest/gears/writegear/compression/overview/) for encoding real-time video frames to a lossless compressed multimedia output file(s)/stream(s). 
+**VidGear's [WriteGear API](https://abhitronix.github.io/vidgear/latest/gears/writegear/introduction/)** provides a flexible and robust wrapper over FFmpeg (compression mode) for encoding real-time video frames into lossless multimedia files or streams.
 
-    DeFFcode's FFdecoder API in conjunction with WriteGear API creates a high-level **High-performance Lossless FFmpeg Transcoding _(Decoding + Encoding)_ Pipeline :fire:** that is able to exploit almost any FFmpeg parameter for achieving anything imaginable with multimedia video data all while allow us to manipulate the real-time video frames with immense flexibility. 
+Combined with **DeFFcode's FFdecoder API**, it enables a high-level **lossless FFmpeg transcoding pipeline (decoding + encoding)** with full control over FFmpeg parameters and real-time frame manipulation.
 
-In this example we will decode different pixel formats video frames from a given Video file _(say `foo.mp4`)_ in FFdecoder API, and encode them into lossless video file with controlled framerate using WriteGear API in real-time. 
+In this example, we will decode video frames with different pixel formats from a given video file *(e.g., `foo.mp4`)* using the FFdecoder API, and then encode them into a lossless video file with a controlled framerate using the WriteGear API in real time.
 
 !!! info "Additional Parameters in WriteGear API"
     

--- a/docs/recipes/basic/transcode-live-frames.md
+++ b/docs/recipes/basic/transcode-live-frames.md
@@ -288,7 +288,35 @@ In this example we will decode different pixel formats video frames from a given
 
 ## Transcoding lossless video using WriteGear API
 
-!!! danger "==WriteGear's Compression Mode support for FFdecoder API is currently in beta so you can expect much higher than usual CPU utilization!=="
+!!! danger "High CPU Usage when chaining FFdecoder with WriteGear"
+
+    When chaining FFdecoder with WriteGear, both FFmpeg processes _(decoding + encoding)_ run **as fast as your hardware allows** with no artificial pacing between them. This causes the pipeline to max out your CPU to process the video in the shortest time possible, which may be undesirable.
+
+    You can mitigate this in two ways depending on your use case:
+
+    === "Throttle to Real-Time Speed"
+
+        Pass the `-re` flag via FFdecoder's `-ffprefixes` parameter to force FFmpeg to read the input at its native framerate. This naturally paces the pipeline to real-time speed and **drastically reduces CPU usage**:
+
+        ```python
+        # force input to be read at native framerate
+        decoder = FFdecoder("foo.mp4", frame_format="bgr24", **{"-ffprefixes": ["-re"]}).formulate()
+        ```
+
+    === "Limit FFmpeg Threads"
+
+        Pass `-threads` to both FFdecoder and WriteGear to cap the number of CPU threads each FFmpeg process may use. This leaves headroom for other system tasks:
+
+        ```python
+        # limit decoder to 2 threads
+        decoder = FFdecoder("foo.mp4", frame_format="bgr24", **{"-threads": 2}).formulate()
+
+        # limit encoder to 2 threads
+        writer = WriteGear(output="output_foo.mp4", **{"-input_framerate": fps, "-threads": 2})
+        ```
+
+    !!! tip "Hardware Acceleration"
+        If your machine has a dedicated GPU, you can offload encoding to the GPU entirely — for example by passing `"-vcodec": "h264_nvenc"` to WriteGear _(NVIDIA)_ — shifting the heavy lifting off the CPU.
 
 ???+ quote "Lossless transcoding  with FFdecoder and WriteGear API"
     
@@ -325,7 +353,7 @@ In this example we will decode different pixel formats video frames from a given
 
     # Define writer with default parameters and suitable
     # output filename for e.g. `output_foo.mp4`
-    writer = WriteGear(output_filename="output_foo.mp4", **output_params)
+    writer = WriteGear(output="output_foo.mp4", **output_params)
 
     # grab the BGR24 frame from the decoder
     for frame in decoder.generateFrame():
@@ -367,7 +395,7 @@ In this example we will decode different pixel formats video frames from a given
 
     # Define writer with default parameters and suitable
     # output filename for e.g. `output_foo.mp4`
-    writer = WriteGear(output_filename="output_foo.mp4", **output_params)
+    writer = WriteGear(output="output_foo.mp4", **output_params)
 
     # grab the BGR24 frame from the decoder
     for frame in decoder.generateFrame():
@@ -409,7 +437,7 @@ In this example we will decode different pixel formats video frames from a given
 
     # Define writer with default parameters and suitable
     # output filename for e.g. `output_foo_gray.mp4`
-    writer = WriteGear(output_filename="output_foo_gray.mp4", **output_params)
+    writer = WriteGear(output="output_foo_gray.mp4", **output_params)
 
     # grab the GRAYSCALE frame from the decoder
     for frame in decoder.generateFrame():
@@ -457,7 +485,7 @@ In this example we will decode different pixel formats video frames from a given
 
     # Define writer with default parameters and suitable
     # output filename for e.g. `output_foo_yuv.mp4`
-    writer = WriteGear(output_filename="output_foo_yuv.mp4", logging=True, **output_params)
+    writer = WriteGear(output="output_foo_yuv.mp4", logging=True, **output_params)
 
     # grab the YUV420 frame from the decoder
     for frame in decoder.generateFrame():

--- a/docs/reference/ffdecoder/params.md
+++ b/docs/reference/ffdecoder/params.md
@@ -527,7 +527,7 @@ This parameter can be used to manually assigns the system _file-path/directory_ 
 
     ??? question "How to change FFmpeg Static Binaries download directory?"
 
-        You can use `-ffmpeg_download_path` _(via. [`-custom_sourcer_params`](#exclusive-parameters))_ exclusive parameter in FFdecoder API to set the custom directory for downloading FFmpeg Static Binaries during the [Auto-Installation](../../../installation/ffmpeg_install/#a-auto-installation) step on Windows Machines. If this parameter is not altered, then these binaries will auto-save to the default temporary directory (for e.g. `C:/User/temp`) on your windows machine. It can be used as follows in FFdecoder API:
+        You can use `-ffmpeg_download_path` _(via. [`-custom_sourcer_params`](#b-exclusive-parameters))_ exclusive parameter in FFdecoder API to set the custom directory for downloading FFmpeg Static Binaries during the [Auto-Installation](../../../installation/ffmpeg_install/#a-auto-installation) step on Windows Machines. If this parameter is not altered, then these binaries will auto-save to the default temporary directory (for e.g. `C:/User/temp`) on your windows machine. It can be used as follows in FFdecoder API:
 
         ```python
         # # define suitable parameter to download at "C:/User/foo/foo1"
@@ -698,7 +698,7 @@ These parameters are discussed below:
 
 &ensp;
 
-* **`-custom_sourcer_params`** _(dict)_ :  This attribute assigns all [**Exclusive Parameter**](../../sourcer/params/#exclusive-parameters) meant for Sourcer API's `sourcer_params` dictionary parameter directly through FFdecoder API. Its usage is as follows: 
+* **`-custom_sourcer_params`** _(dict)_ :  This attribute assigns all [**Exclusive Parameter**](../../sourcer/params/#b-exclusive-parameters) meant for Sourcer API's `sourcer_params` dictionary parameter directly through FFdecoder API. Its usage is as follows: 
     
     ```python
     # define suitable parameter meant for `sourcer_params`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ theme:
   language: en
   features:
     - announce.dismiss
+    - navigation.prune
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.indexes
@@ -83,20 +84,24 @@ theme:
 # Plugins
 plugins:
   - search
-  - git-revision-date-localized
+  - git-revision-date-localized:
+      enable_creation_date: true
+      fallback_to_build_date: true
   - minify:
       minify_html: true
   - mkdocstrings:
       handlers:
         python:
           options:
-            show_root_heading: false
-            show_root_toc_entry: false
-            show_source: true
-            heading_level: 3
-  - exclude:
-      glob:
-        - overrides/assets/README.md
+            filters:
+              - "!^_"
+              - "^__init__$"
+              - "^__call__$"
+            extra:
+              show_root_heading: false
+              show_root_toc_entry: false
+              show_source: true
+              heading_level: 3
 
 # Customization
 extra:
@@ -139,7 +144,8 @@ markdown_extensions:
       permalink_title: Anchor link to this section for reference
   - codehilite:
       guess_lang: false
-  - pymdownx.arithmatex
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.betterem:
       smart_enable: all
   - pymdownx.caret
@@ -163,7 +169,11 @@ markdown_extensions:
   - pymdownx.smartsymbols
   - pymdownx.snippets:
       check_paths: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:
@@ -171,7 +181,14 @@ markdown_extensions:
   - pymdownx.tilde
   - pymdownx.striphtml:
       strip_comments: true
-  - pymdownx.magiclink
+  - pymdownx.magiclink:
+      normalize_issue_symbols: true
+      repo_url_shorthand: true
+      user: abhiTronix
+      repo: deffcode
+
+exclude_docs: |
+  overrides/assets/README.md
 
 # Page tree
 nav:
@@ -187,7 +204,7 @@ nav:
           - Pull Request(PR) Guidelines: contribution/PR.md
       - Changelog: changelog.md
       - License: license.md
-  - Recipies:
+  - Recipes:
       - Basic Recipes:
           - Overview: recipes/basic/index.md
           - Decoding Video Files: recipes/basic/decode-video-files.md
@@ -198,7 +215,7 @@ nav:
           - Transcoding Live Simple Filtergraphs: recipes/basic/transcode-live-frames-simplegraphs.md
           - Saving Key-frames as Image: recipes/basic/save-keyframe-image.md
           - Extracting video metadata: recipes/basic/extract-video-metadata.md
-      - Advanced Recipies:
+      - Advanced Recipes:
           - Overview: recipes/advanced/index.md
           - Decoding Live Virtual Sources: recipes/advanced/decode-live-virtual-sources.md
           - Decoding Live Feed Devices: recipes/advanced/decode-live-feed-devices.md


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
When using FFdecoder and WriteGear (from vidgear) together to decode and re-encode video frames, users may experience very high CPU utilization. 


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the DeFFcode [PR Guidelines](https://abhitronix.github.io/deffcode/latest/contribution/PR/).
- [x] I have read the DeFFcode [Documentation](https://abhitronix.github.io/deffcode/latest).
- [x] I have updated the documentation files accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#57 


### Context
<!--- Why is this change required? What problem does it solve? -->
When running FFdecoder.generateFrame() directly into WriteGear.write(), the CPU usage spikes to its absolute maximum. This PR adds a "Best Practices" or "Troubleshooting" section in the documentation explaining why this CPU spike happens and providing parameters to mitigate it depending on the user's goal.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Miscellaneous (if available):
<!-- Provide any screenshots or any Miscellaneous info if available or else remove this block -->
None