### PR TITLE
58 idea dropped support for python 39x and 38x legacies

### DIFF
--- a/.github/workflows/CIlinux.yml
+++ b/.github/workflows/CIlinux.yml
@@ -39,13 +39,13 @@ on:
 jobs:
   test:
     name: CI Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install APT Dependencies
@@ -75,7 +75,7 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         if: success()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           name: ${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs_deployer.yml
+++ b/.github/workflows/docs_deployer.yml
@@ -23,7 +23,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
   GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
   GIT_NAME: ${{ secrets.GIT_NAME }}
   GIT_EMAIL: ${{ secrets.GIT_EMAIL }}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,6 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python39-x64"
-      PYTHON_VERSION: "3.9.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python310-x64"
       PYTHON_VERSION: "3.10.x"
       PYTHON_ARCH: "64"
@@ -34,7 +26,15 @@ environment:
       PYTHON_VERSION: "3.11.x"
       PYTHON_ARCH: "64"
 
-build: off
+    - PYTHON: "C:\\Python312-x64"
+      PYTHON_VERSION: "3.12.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python313-x64"
+      PYTHON_VERSION: "3.13.x"
+      PYTHON_ARCH: "64"
+
+build: false
 
 version: '{branch}-{build}'
 
@@ -71,4 +71,4 @@ test_script:
   - cmd: python -m pytest --verbose --capture=no --cov-report term-missing --cov=deffcode tests/
 
 after_test:
-  - cmd: python -m codecov 
+  - cmd: python -m codecov

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,14 +37,14 @@ pool:
 
 strategy:
   matrix:
-    Python38:
-      python.version: "3.8"
-    Python39:
-      python.version: "3.9"
     Python310:
       python.version: "3.10"
     Python311:
       python.version: "3.11"
+    Python312:
+      python.version: "3.12"
+    Python313:
+      python.version: "3.13"
 
 steps:
 - task: UsePythonVersion@0
@@ -76,18 +76,18 @@ steps:
 - script: |
     timeout 1500 pytest -sv --cov=deffcode --cov-report=xml --cov-report=html --cov-report term-missing tests/ || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; else echo "##vso[task.setvariable variable=exit_code]$code"; fi
   displayName: 'pytest'
-  
+
 - bash: |
     echo "Exit Code was: $(exit_code)"
     curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-    curl -Os https://uploader.codecov.io/latest/macos/codecov
-    curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
-    curl -Os https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig
+    curl -Os https://cli.codecov.io/latest/macos/codecov
+    curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM
+    curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM.sig
     gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
     shasum -a 256 -c codecov.SHA256SUM
     chmod +x codecov
     if [ "$(exit_code)" != "124" ]; then
-      ./codecov -t $CODECOV_TOKEN -f coverage.xml -C $(Build.SourceVersion) -B $(Build.SourceBranch) -b $(Build.BuildNumber);
+      ./codecov  --verbose upload-process --fail-on-error -t $CODECOV_TOKEN -f coverage.xml -C $(Build.SourceVersion) -B $(Build.SourceBranch) -b $(Build.BuildNumber);
     else
       echo "Timeout test - Skipped Codecov!"; 
     fi


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
This PR removes support for the legacy Python 3.9.x and 3.8.x versions, and adds support for newer Python 3.12.x and 3.13.x releases.


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the DeFFcode [PR Guidelines](https://abhitronix.github.io/deffcode/latest/contribution/PR/).
- [x] I have read the DeFFcode [Documentation](https://abhitronix.github.io/deffcode/latest).
- [x] I have updated the documentation files accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#58 

### Context
<!--- Why is this change required? What problem does it solve? -->
As of 31 Oct 2025, Python 3.9.x has reached its end of support, meaning it no longer receives security updates or general availability support: https://endoflife.date/python. This PR removes support for the legacy Python 3.9.x and 3.8.x versions, and adds support for newer Python 3.12.x and 3.13.x releases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


### Miscellaneous (if available):
<!-- Provide any screenshots or any Miscellaneous info if available or else remove this block -->
https://endoflife.date/python